### PR TITLE
adding Zabo API under APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 - [The Graph](https://thegraph.com/explorer/subgraph/graphprotocol/uniswap)
 - [Loanscan](https://uniswap-api.loanscan.io/)
 - [Blocklytics](https://docs.blocklytics.org/apis/uniswap-api) (API key required)
+- [Zabo](https://zabo.com/) (API key required)
 
 ## Integrations
 


### PR DESCRIPTION
Zabo API supports multiple Uniswap-dedicated functionality:
- Parsing trades and converting into a standard format (transaction history endpoint)
- Show balances for pool LP tokens - including USD equivalent (pool LP token balance and exchange rate endpoint) 
- Any Ethereum wallet connected via Zabo automatically gets the above

https://zabo.com/integrations/uniswap-api/